### PR TITLE
Dispatching couriers

### DIFF
--- a/factory/factory.go
+++ b/factory/factory.go
@@ -60,7 +60,7 @@ func (f *Factory) Intake(order Order) {
 		f.Log(`Placed order for %s on overflow`, order.Item.Id)
 	} else {
 		acceptedOrder = false
-		f.Log(`Factory at capacity`)
+		f.Log(`Factory at capacity ¯\_(ツ)_/¯`)
 	}
 
 	if acceptedOrder {

--- a/factory/factory.go
+++ b/factory/factory.go
@@ -56,5 +56,7 @@ func (f *Factory) Intake(order Order) {
 	} else if overflowShelf.HasCapacity() {
 		overflowShelf.Register(order)
 		f.Log(`Placed order for %s on overflow`, order.Item.Id)
+	} else {
+		f.Log(`Factory at capacity`)
 	}
 }

--- a/factory/shelf.go
+++ b/factory/shelf.go
@@ -37,3 +37,19 @@ func (s *Shelf) Register(order Order) {
 func (s *Shelf) HasCapacity() bool {
 	return (s.Capacity > s.FoodOnShelf)
 }
+
+func (s *Shelf) Contains(order Order) bool {
+	orders := s.orders
+	id := order.Item.Id
+
+	_, exists := orders[id]
+
+	return exists
+}
+
+func (s *Shelf) Remove(order Order) {
+	s.lock.Lock()
+	delete(s.orders, order.Item.Id)
+	s.FoodOnShelf -= 1
+	s.lock.Unlock()
+}

--- a/main.go
+++ b/main.go
@@ -7,7 +7,10 @@ import (
 )
 
 func main() {
-	settings := tools.GetSimulationSettings()
+	settings, err := tools.GetSimulationSettings()
+	if err != nil {
+		panic(err)
+	}
 	tools.PrintArgs(settings)
 
 	msBetweenOrders := 1000.0 / float32(settings.IngestionRate)

--- a/tools/args.go
+++ b/tools/args.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 )
@@ -11,7 +12,7 @@ type SimulationSettings struct {
 	CourierSpeedHigh int
 }
 
-func GetSimulationSettings() SimulationSettings {
+func GetSimulationSettings() (SimulationSettings, error) {
 	IngestionRate := flag.Int("IngestionRate", 3, "How quickly orders come in, in orders / second")
 	CourierSpeedLow := flag.Int("CourierSpeedLow", 2000, "How quickly the fastest couriers can fulfull an order, in ms")
 	CourierSpeedHigh := flag.Int("CourierSpeedHigh", 6000, "How slowly couriers can fulfull an order, ms")
@@ -20,10 +21,15 @@ func GetSimulationSettings() SimulationSettings {
 
 	if *CourierSpeedHigh < *CourierSpeedLow {
 		msg := fmt.Sprintf(`Invalid courier speed interval: [%d, %d]`, *CourierSpeedLow, *CourierSpeedHigh)
-		panic(msg)
+		return SimulationSettings{}, errors.New(msg)
 	}
 
-	return SimulationSettings{*IngestionRate, *CourierSpeedLow, *CourierSpeedHigh}
+	if *IngestionRate <= 0 {
+		msg := fmt.Sprintf(`Invalid ingestion rate: %d / second`, *IngestionRate)
+		return SimulationSettings{}, errors.New(msg)
+	}
+
+	return SimulationSettings{*IngestionRate, *CourierSpeedLow, *CourierSpeedHigh}, nil
 }
 
 func PrintArgs(settings SimulationSettings) {

--- a/tools/args.go
+++ b/tools/args.go
@@ -13,24 +13,25 @@ type SimulationSettings struct {
 
 func GetSimulationSettings() SimulationSettings {
 	IngestionRate := flag.Int("IngestionRate", 3, "How quickly orders come in, in orders / second")
-	CourierSpeedLow := flag.Int("CourierSpeedLow", 2, "How quickly the fastest couriers can fulfull an order, in seconds")
-	CourierSpeedHigh := flag.Int("CourierSpeedHigh", 6, "How slowly couriers can fulfull an order, seconds")
+	CourierSpeedLow := flag.Int("CourierSpeedLow", 2000, "How quickly the fastest couriers can fulfull an order, in ms")
+	CourierSpeedHigh := flag.Int("CourierSpeedHigh", 6000, "How slowly couriers can fulfull an order, ms")
 
 	flag.Parse()
 
-	return SimulationSettings{*IngestionRate, *CourierSpeedHigh, *CourierSpeedLow}
+	if *CourierSpeedHigh < *CourierSpeedLow {
+		msg := fmt.Sprintf(`Invalid courier speed interval: [%d, %d]`, *CourierSpeedLow, *CourierSpeedHigh)
+		panic(msg)
+	}
+
+	return SimulationSettings{*IngestionRate, *CourierSpeedLow, *CourierSpeedHigh}
 }
 
 func PrintArgs(settings SimulationSettings) {
 	fmt.Printf(`
-###########################
-#                         #
-# Simulation with params: #
-#   IngestionRate: %d      #
-#   CourierSpeedLow: %d    #
-#   CourierSpeedHigh: %d   #
-#                         #
-###########################
+Simulation with params:
+  IngestionRate: %d
+  CourierSpeedLow: %d
+  CourierSpeedHigh: %d
 
 time,message,hot,cold,frozen,overflow
 `, settings.IngestionRate, settings.CourierSpeedLow, settings.CourierSpeedHigh)


### PR DESCRIPTION
Once an order has been registered, we need to dispatch a courier to deliver it. We are not considering how long it takes to cook each order, rather assuming each dish is cooked and prepared instantly.

- [x] After a random amount of time, a courier is dispatched
	- Tuned via the CLI args `CourierSpeedLow` and `CourierSpeedHigh`
	- Validation of these CLI args
- [x] Couriers clear the orders off the shelf

Right now, we reach a capacity depending on how much shelf space we have.