### PR TITLE
Making Space

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,4 +28,4 @@ jobs:
       run: go test -v
 
     - name: Runs for a minute
-      name: echo it works!
+      run: echo it works!

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,5 +24,8 @@ jobs:
     - name: Build
       run: go build main
 
-    - name: Test
+    - name: Unit Test
       run: go test -v
+
+    - name: Runs for a minute
+      name: echo it works!

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,7 +1,7 @@
 # This workflow will build a golang project
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
 
-name: Go
+name: Test Suite
 
 on:
   push:
@@ -21,11 +21,8 @@ jobs:
       with:
         go-version: '1.23.0'
 
-    - name: Build
-      run: go build main
-
     - name: Unit Test
       run: go test -v
 
-    - name: Runs for a minute
-      run: echo it works!
+    - name: Build and run for a minute
+      run: sh smoke.sh

--- a/README.md
+++ b/README.md
@@ -81,11 +81,11 @@ flags with their default value:
 ```shell
 ./main
   # how quickly orders come in, in orders / second
-  -IngestionRate=3
+  --ingestionRate=3
   
   # the fastest couriers can fulfull an order, in seconds
-  -CourierSpeedLow=2
+  --courierSpeedLow=2
   
   # the slowest couriers can fulfull an order, seconds
-  -CourierSpeedHigh=6
+  --courierSpeedHigh=6
 ```

--- a/factory/factory.go
+++ b/factory/factory.go
@@ -31,7 +31,7 @@ func NewFactory(settings tools.SimulationSettings) Factory {
 	return newFactory
 }
 
-func (f *Factory) Log(msg string, args ...any) {
+func (f *Factory) log(msg string, args ...any) {
 	var now int64 = time.Now().Unix()
 	var message string = fmt.Sprintf(msg, args...)
 
@@ -47,7 +47,7 @@ func (f *Factory) Log(msg string, args ...any) {
 }
 
 func (f *Factory) Intake(order Order) {
-	f.Log(`Placing order for %s for %s`, order.Item.Id, order.Item.Temp)
+	f.log(`Placing order for %s for %s`, order.Item.Id, order.Item.Temp)
 
 	var targetShelf *Shelf = f.Storage[order.Item.Temp]
 	var overflowShelf *Shelf = f.Storage["overflow"]
@@ -55,19 +55,19 @@ func (f *Factory) Intake(order Order) {
 
 	if targetShelf.HasCapacity() {
 		targetShelf.Register(order)
-		f.Log(`Placed order for %s on %s`, order.Item.Id, order.Item.Temp)
+		f.log(`Placed order for %s on %s`, order.Item.Id, order.Item.Temp)
 	} else if overflowShelf.HasCapacity() {
 		overflowShelf.Register(order)
-		f.Log(`Placed order for %s on overflow`, order.Item.Id)
+		f.log(`Placed order for %s on overflow`, order.Item.Id)
 	} else {
 		// attempt to make space
 		var madeSpace bool = f.attemptToMakeSpace()
 		if madeSpace {
 			overflowShelf.Register(order)
-			f.Log(`Placed order for %s on overflow`, order.Item.Id)
+			f.log(`Placed order for %s on overflow`, order.Item.Id)
 		} else {
 			acceptedOrder = false
-			f.Log(`Factory at capacity ¯\_(ツ)_/¯`)
+			f.log(`Factory at capacity ¯\_(ツ)_/¯`)
 		}
 	}
 
@@ -75,11 +75,11 @@ func (f *Factory) Intake(order Order) {
 		// we do not pass a channel to this goroutine
 		// because we do not want to block accepting other orders
 		// while accepting this one
-		go f.DispatchCourier(order)
+		go f.dispatchCourier(order)
 	}
 }
 
-func (f *Factory) DispatchCourier(order Order) {
+func (f *Factory) dispatchCourier(order Order) {
 	// wait a random amount of time to deliver the order
 	// this is basically simulating cooking time
 	var low int = f.Settings.CourierSpeedLow
@@ -104,9 +104,9 @@ func (f *Factory) DispatchCourier(order Order) {
 	}
 
 	if deliveryStatus != "removed" {
-		f.Log(`Delivered %s from %s shelf`, order.Item.Id, deliveryStatus)
+		f.log(`Delivered %s from %s shelf`, order.Item.Id, deliveryStatus)
 	} else {
-		f.Log("Threw away %s", order.Item.Id)
+		f.log("Threw away %s", order.Item.Id)
 	}
 }
 
@@ -118,7 +118,7 @@ func (f *Factory) attemptToMakeSpace() bool {
 		if f.Storage[order.Item.Temp].HasCapacity() {
 			overflow.Remove(order)
 			f.Storage[order.Item.Temp].Register(order)
-			f.Log(`Moved %s from overflow to %s`, order.Item.Id, order.Item.Temp)
+			f.log(`Moved %s from overflow to %s`, order.Item.Id, order.Item.Temp)
 			madeSpace = true
 		}
 	}

--- a/factory/factory.go
+++ b/factory/factory.go
@@ -32,10 +32,10 @@ func NewFactory(settings tools.SimulationSettings) Factory {
 }
 
 func (f *Factory) Log(msg string, args ...any) {
-	now := time.Now().Unix()
-	message := fmt.Sprintf(msg, args...)
+	var now int64 = time.Now().Unix()
+	var message string = fmt.Sprintf(msg, args...)
 
-	output := fmt.Sprintf(
+	var output string = fmt.Sprintf(
 		`%d,%s,%d,%d,%d,%d`,
 		now, message,
 		f.Storage["hot"].FoodOnShelf,
@@ -49,9 +49,9 @@ func (f *Factory) Log(msg string, args ...any) {
 func (f *Factory) Intake(order Order) {
 	f.Log(`Placing order for %s for %s`, order.Item.Id, order.Item.Temp)
 
-	targetShelf := f.Storage[order.Item.Temp]
-	overflowShelf := f.Storage["overflow"]
-	acceptedOrder := true
+	var targetShelf *Shelf = f.Storage[order.Item.Temp]
+	var overflowShelf *Shelf = f.Storage["overflow"]
+	var acceptedOrder bool = true
 
 	if targetShelf.HasCapacity() {
 		targetShelf.Register(order)
@@ -61,7 +61,7 @@ func (f *Factory) Intake(order Order) {
 		f.Log(`Placed order for %s on overflow`, order.Item.Id)
 	} else {
 		// attempt to make space
-		madeSpace := f.attemptToMakeSpace()
+		var madeSpace bool = f.attemptToMakeSpace()
 		if madeSpace {
 			overflowShelf.Register(order)
 			f.Log(`Placed order for %s on overflow`, order.Item.Id)
@@ -72,6 +72,9 @@ func (f *Factory) Intake(order Order) {
 	}
 
 	if acceptedOrder {
+		// we do not pass a channel to this goroutine
+		// because we do not want to block accepting other orders
+		// while accepting this one
 		go f.DispatchCourier(order)
 	}
 }
@@ -81,13 +84,13 @@ func (f *Factory) DispatchCourier(order Order) {
 	// this is basically simulating cooking time
 	var low int = f.Settings.CourierSpeedLow
 	var high int = f.Settings.CourierSpeedHigh
-	deliverySpeed := (low + rand.Intn(high-low))
-	interval := time.Duration(deliverySpeed * int(time.Millisecond))
+	var deliverySpeed int = (low + rand.Intn(high-low))
+	var interval time.Duration = time.Duration(deliverySpeed * int(time.Millisecond))
 	time.Sleep(interval)
 
 	// now attempt to deliver the order
-	targetShelf := f.Storage[order.Item.Temp]
-	overflowShelf := f.Storage["overflow"]
+	var targetShelf *Shelf = f.Storage[order.Item.Temp]
+	var overflowShelf *Shelf = f.Storage["overflow"]
 	var deliveryStatus string
 
 	if targetShelf.Contains(order) {
@@ -108,10 +111,10 @@ func (f *Factory) DispatchCourier(order Order) {
 }
 
 func (f *Factory) attemptToMakeSpace() bool {
-	madeSpace := false
-	overflow := f.Storage["overflow"]
+	var madeSpace bool = false
+	var overflow *Shelf = f.Storage["overflow"]
 	for key := range maps.Keys(f.Storage["overflow"].Orders) {
-		order := Order{Item: overflow.Orders[key], Id: key}
+		var order Order = Order{Item: overflow.Orders[key], Id: key}
 		if f.Storage[order.Item.Temp].HasCapacity() {
 			overflow.Remove(order)
 			f.Storage[order.Item.Temp].Register(order)

--- a/factory/shelf.go
+++ b/factory/shelf.go
@@ -10,11 +10,11 @@ type Shelf struct {
 	Temperature string
 	Capacity    int
 	FoodOnShelf int
-	Orders      map[string]string
+	Orders      map[string]Item
 }
 
 func NewShelf(name string, temperature string, capacity int) *Shelf {
-	orders := make(map[string]string)
+	orders := make(map[string]Item)
 
 	shelf := &Shelf{
 		Name:        name,
@@ -29,7 +29,7 @@ func NewShelf(name string, temperature string, capacity int) *Shelf {
 
 func (s *Shelf) Register(order Order) {
 	s.Lock.Lock()
-	s.Orders[order.Item.Id] = order.Item.Temp
+	s.Orders[order.Item.Id] = order.Item
 	s.FoodOnShelf += 1
 	s.Lock.Unlock()
 }

--- a/factory/shelf.go
+++ b/factory/shelf.go
@@ -6,32 +6,32 @@ import (
 
 type Shelf struct {
 	Name        string
-	lock        sync.Mutex
+	Lock        sync.Mutex
 	Temperature string
 	Capacity    int
 	FoodOnShelf int
-	orders      map[string]bool
+	Orders      map[string]string
 }
 
 func NewShelf(name string, temperature string, capacity int) *Shelf {
-	orders := make(map[string]bool)
+	orders := make(map[string]string)
 
 	shelf := &Shelf{
 		Name:        name,
 		Temperature: temperature,
 		Capacity:    capacity,
 		FoodOnShelf: 0,
-		orders:      orders,
+		Orders:      orders,
 	}
 
 	return shelf
 }
 
 func (s *Shelf) Register(order Order) {
-	s.lock.Lock()
-	s.orders[order.Item.Id] = true
+	s.Lock.Lock()
+	s.Orders[order.Item.Id] = order.Item.Temp
 	s.FoodOnShelf += 1
-	s.lock.Unlock()
+	s.Lock.Unlock()
 }
 
 func (s *Shelf) HasCapacity() bool {
@@ -39,7 +39,7 @@ func (s *Shelf) HasCapacity() bool {
 }
 
 func (s *Shelf) Contains(order Order) bool {
-	orders := s.orders
+	orders := s.Orders
 	id := order.Item.Id
 
 	_, exists := orders[id]
@@ -48,8 +48,8 @@ func (s *Shelf) Contains(order Order) bool {
 }
 
 func (s *Shelf) Remove(order Order) {
-	s.lock.Lock()
-	delete(s.orders, order.Item.Id)
+	s.Lock.Lock()
+	delete(s.Orders, order.Item.Id)
 	s.FoodOnShelf -= 1
-	s.lock.Unlock()
+	s.Lock.Unlock()
 }

--- a/main.go
+++ b/main.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-func main() {
+func startFactory() {
 	settings, err := tools.GetSimulationSettings()
 	if err != nil {
 		panic(err)
@@ -23,4 +23,12 @@ func main() {
 		facility.Intake(order)
 		time.Sleep(interval)
 	}
+}
+
+func main() {
+	go startFactory()
+
+	// start any other concurrent processes here
+	// maybe a DB connection, or a web server
+	select {}
 }

--- a/smoke.sh
+++ b/smoke.sh
@@ -1,0 +1,7 @@
+# build application
+go build main
+
+# run for 30 seconds
+./main &
+sleep 30
+kill "$!"

--- a/tools/args.go
+++ b/tools/args.go
@@ -13,13 +13,13 @@ type SimulationSettings struct {
 }
 
 func GetSimulationSettings() (SimulationSettings, error) {
-	IngestionRate := flag.Int("IngestionRate", 3, "How quickly orders come in, in orders / second")
-	CourierSpeedLow := flag.Int("CourierSpeedLow", 2000, "How quickly the fastest couriers can fulfull an order, in ms")
-	CourierSpeedHigh := flag.Int("CourierSpeedHigh", 6000, "How slowly couriers can fulfull an order, ms")
+	IngestionRate := flag.Int("ingestionRate", 3, "How quickly orders come in, in orders / second")
+	CourierSpeedLow := flag.Int("courierSpeedLow", 2000, "How quickly the fastest couriers can fulfull an order, in ms")
+	CourierSpeedHigh := flag.Int("courierSpeedHigh", 6000, "How slowly couriers can fulfull an order, ms")
 
 	flag.Parse()
 
-	if *CourierSpeedHigh < *CourierSpeedLow {
+	if (*CourierSpeedHigh <= *CourierSpeedLow) || (*CourierSpeedLow <= 0) {
 		msg := fmt.Sprintf(`Invalid courier speed interval: [%d, %d]`, *CourierSpeedLow, *CourierSpeedHigh)
 		return SimulationSettings{}, errors.New(msg)
 	}


### PR DESCRIPTION
There is a corner case that we have not yet considered. Right now, when we intake the order we do two things:

1. Check the target shelf for space
2. Check the overflow shelf for space

If neither of these have space, we give up. We can do better. Before giving up, we can instead go through the overflow shelf and see if any items there can be moved *back* to their original target shelves. This is possible in the following case:

1. We fill up the `hot`, `cold`, and `overflow` shelves
2. We deliver some items off the `cold` shelf
3. Now some `cold` items can be moved *back* from the `overflow` shelf